### PR TITLE
Add history tracking, responsive tables, and active insight pagination

### DIFF
--- a/backend/ai/orchestrator/persistInsights.js
+++ b/backend/ai/orchestrator/persistInsights.js
@@ -1,6 +1,6 @@
 import {db, FieldValue} from "../../../lib/firebaseAdmin.js";
 
-const EXPIRY_MS = 2 * 24 * 60 * 60 * 1000;
+const EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
 
 export const persistInsights = async ({userId, insight}) => {
     if(!insight) return false;
@@ -17,6 +17,7 @@ export const persistInsights = async ({userId, insight}) => {
 const addInsight = async ({userId, insight}) => {
     const insightWithExpiry = {
         ...insight,
+        status: "ACTIVE",
         createdAt: FieldValue.serverTimestamp(),
         expiresAt: Date.now() + EXPIRY_MS,
     } 

--- a/backend/ai/services/anomaly.js
+++ b/backend/ai/services/anomaly.js
@@ -37,13 +37,12 @@ export const runAnomalyService = async ({data, userId, isDemo} = {}) => {
 
 
 const insightData = (anomaly, response, model) => ({
-      id: anomaly.id,
-      type: "anomaly",
-      actionType: "suggestion",
-      severity: anomaly.risk.level,
-      category: anomaly.category,
-      year: new Date().getFullYear(),
-      baselineValue: anomaly.signal.baseline_value,
-      agent: response,
-      modelUsed: model
-      }    )
+  id: anomaly.id,
+  type: "anomaly",
+  severity: anomaly.risk.level,
+  category: anomaly.category,
+  year: new Date().getFullYear(),
+  baselineValue: anomaly.signal.baseline_value,
+  agent: response,
+  modelUsed: model
+});

--- a/backend/ai/services/budget.js
+++ b/backend/ai/services/budget.js
@@ -40,8 +40,6 @@ const insightData = (data, response, model) => {
   return {
     id: data.id,
       type: "budget-compliance",
-      actionType: "suggestion",
-      createdAt: new Date(),
       severity: data.derived.risk_level,
       category: data.category,
       year: data.budget.year,

--- a/backend/ai/services/cashflow.js
+++ b/backend/ai/services/cashflow.js
@@ -54,8 +54,6 @@ const insightData = (cashflowData, response, model) => {
   return {
     id: cashflowData.id,
       type: "cashflow",
-      actionType: "suggestion",
-      createdAt: new Date(),
       category: null,
       severity: riskLevel,
       month: cashflowData.period.month,

--- a/backend/ai/services/risk.js
+++ b/backend/ai/services/risk.js
@@ -41,7 +41,6 @@ const insightData = (data, response, model) => {
     return {
         id: data.id,
         type: "financial-risk",
-        actionType: "suggestion",
         severity: data.risk.level,
         score: data.risk.score,
         month: data.period.month,

--- a/backend/tests/orchestrator.test.js
+++ b/backend/tests/orchestrator.test.js
@@ -180,7 +180,7 @@ describe("orchestrator", () => {
 
     const result = await runPipeline();
 
-    expect(result).toEqual([]);
+    expect(result).toEqual({ insight: null, reason: "NO_ELIGIBLE_SIGNAL" });
     expect(generateAIResponse).not.toHaveBeenCalled();
   });
 
@@ -205,7 +205,7 @@ describe("orchestrator", () => {
 
     const result = await runPipeline();
 
-    expect(result).toEqual([]);
+    expect(result).toEqual({ insight: null, reason: "AGENT_EXECUTION_FAILED" });
     expect(markSignalTriggerFailed).toHaveBeenCalledTimes(1);
     expect(markSignalTriggered).not.toHaveBeenCalled();
   });
@@ -215,7 +215,10 @@ describe("orchestrator", () => {
 
     const result = await runPipeline();
 
-    expect(result).toEqual([]);
+    expect(result).toEqual({
+      insight: expect.objectContaining({ id: "risk-jun", type: "financial-risk" }),
+      reason: "INSIGHT_PERSISTENCE_FAILED",
+    });
     expect(markSignalTriggerFailed).toHaveBeenCalledTimes(1);
     expect(markSignalTriggered).not.toHaveBeenCalled();
   });
@@ -228,7 +231,7 @@ describe("orchestrator", () => {
     expect(reserveSignalTrigger).toHaveBeenCalledTimes(1);
     expect(runAnomalyService).not.toHaveBeenCalled();
     expect(runRiskService).not.toHaveBeenCalled();
-    expect(result).toEqual([]);
+    expect(result).toEqual({ insight: null, reason: "NO_RESERVED_SELECTION" });
   });
 
   it("passes demo mode through to agent services without writing in demo runs", async () => {

--- a/src/components/insights/InsightHistoryTable.jsx
+++ b/src/components/insights/InsightHistoryTable.jsx
@@ -1,0 +1,187 @@
+import { useMemo, useState } from "react";
+import clsx from "clsx";
+import ResponsiveTable from "../ui/ResponsiveTable";
+
+const typeLabels = {
+  anomaly: "Anomaly",
+  budget: "Budget",
+  cashflow: "Cash Flow",
+  risk: "Risk",
+};
+
+const filterOptions = {
+  type: ["all", "risk", "anomaly", "budget", "cashflow"],
+  status: ["all", "ACTIVE", "EXPIRED"],
+};
+
+const InsightHistoryTable = ({ histories = [] }) => {
+  const [typeFilter, setTypeFilter] = useState("all");
+  const [statusFilter, setStatusFilter] = useState("all");
+
+  const filteredHistories = useMemo(() => {
+    return histories
+      .filter((history) => typeFilter === "all" || history.type === typeFilter)
+      .filter((history) => statusFilter === "all" || history.status === statusFilter)
+      .sort((a, b) => toDate(b.createdAt) - toDate(a.createdAt));
+  }, [histories, typeFilter, statusFilter]);
+
+  const columns = [
+    {
+      key: "createdAt",
+      header: "Date",
+      render: (history) => formatDate(history.createdAt),
+      cellClassName: "whitespace-nowrap",
+    },
+    {
+      key: "type",
+      header: "Type",
+      render: (history) => typeLabels[history.type] || toTitleCase(history.type),
+      cellClassName: "whitespace-nowrap",
+    },
+    {
+      key: "category",
+      header: "Category",
+      render: (history) => history.category || "N/A",
+      cellClassName: "whitespace-nowrap",
+    },
+    {
+      key: "severity",
+      header: "Severity",
+      render: (history) => (
+        <span className={clsx("rounded-full px-2.5 py-1 text-xs font-semibold", severityClass(history.severity))}>
+          {history.severity}
+        </span>
+      ),
+      cellClassName: "whitespace-nowrap",
+    },
+    {
+      key: "status",
+      header: "Status",
+      render: (history) => (
+        <span className={clsx("rounded-full px-2.5 py-1 text-xs font-semibold", statusClass(history.status))}>
+          {toTitleCase(history.status)}
+        </span>
+      ),
+      cellClassName: "whitespace-nowrap",
+    },
+    {
+      key: "expiresAt",
+      header: "Expires",
+      render: (history) => formatDate(history.expiresAt),
+      cellClassName: "whitespace-nowrap",
+    },
+  ];
+
+  return (
+    <section className="space-y-4">
+      <div className="flex flex-col sm:flex-row gap-3 sm:items-center sm:justify-between">
+        <div>
+          <h3 className="text-xl font-semibold">Insight History</h3>
+          <p className="text-sm text-[rgb(var(--color-muted))]">
+            Active and expired insight records.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <select
+            value={typeFilter}
+            onChange={(event) => setTypeFilter(event.target.value)}
+            className="rounded-md border border-[rgb(var(--color-gray-border))] bg-[rgb(var(--color-bg-card))] px-3 py-2 text-sm outline-none"
+          >
+            {filterOptions.type.map((type) => (
+              <option key={type} value={type}>
+                {type === "all" ? "All types" : typeLabels[type]}
+              </option>
+            ))}
+          </select>
+
+          <select
+            value={statusFilter}
+            onChange={(event) => setStatusFilter(event.target.value)}
+            className="rounded-md border border-[rgb(var(--color-gray-border))] bg-[rgb(var(--color-bg-card))] px-3 py-2 text-sm outline-none"
+          >
+            {filterOptions.status.map((status) => (
+              <option key={status} value={status}>
+                {status === "all" ? "All statuses" : toTitleCase(status)}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <ResponsiveTable
+        columns={columns}
+        rows={filteredHistories}
+        getRowKey={(history) => history.id}
+        emptyMessage="No insight history matches the selected filters."
+        mobileRow={(history) => (
+          <div className="space-y-4">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <p className="text-base font-semibold">
+                  {typeLabels[history.type] || toTitleCase(history.type)}
+                </p>
+                <p className="mt-1 text-sm text-[rgb(var(--color-muted))]">
+                  {history.category || "N/A"}
+                </p>
+              </div>
+
+              <div className="flex flex-col items-end gap-2">
+                {columns[3].render(history)}
+                {columns[4].render(history)}
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3 text-sm">
+              <div>
+                <p className="text-[rgb(var(--color-muted))]">Date</p>
+                <p className="mt-1 font-medium">{formatDate(history.createdAt)}</p>
+              </div>
+              <div>
+                <p className="text-[rgb(var(--color-muted))]">Expires</p>
+                <p className="mt-1 font-medium">{formatDate(history.expiresAt)}</p>
+              </div>
+            </div>
+          </div>
+        )}
+      />
+    </section>
+  );
+};
+
+const severityClass = (severity) => {
+  if (severity === "HIGH") return "bg-red-100 text-red-600";
+  if (severity === "MEDIUM") return "bg-amber-100 text-amber-600";
+
+  return "bg-blue-100 text-blue-600";
+};
+
+const statusClass = (status) => {
+  return status === "ACTIVE"
+    ? "bg-green-100 text-green-700"
+    : "bg-gray-100 text-gray-600";
+};
+
+const toDate = (value) => {
+  if (!value) return new Date(0);
+  if (typeof value?.toDate === "function") return value.toDate();
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? new Date(0) : date;
+};
+
+const formatDate = (value) => {
+  const date = toDate(value);
+  if (date.getTime() === 0) return "N/A";
+
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+  }).format(date);
+};
+
+const toTitleCase = (value = "") => {
+  return value.toLowerCase().replace(/\b\w/g, (letter) => letter.toUpperCase());
+};
+
+export default InsightHistoryTable;

--- a/src/components/transaction/TransactionTable.jsx
+++ b/src/components/transaction/TransactionTable.jsx
@@ -5,6 +5,7 @@ import useCurrencyStore from "../../store/useCurrencyStore";
 import { formatAmount } from "../../utils/formatAmount";
 import useTransactionStore from "../../store/useTransactionStore";
 import useAuthStore from "../../store/useAuthStore";
+import ResponsiveTable from "../ui/ResponsiveTable";
 
 const TransactionTable = () => {
   const user = useAuthStore((state) => state.currentUser);
@@ -24,133 +25,123 @@ const TransactionTable = () => {
     handleEditTransaction,
   } = useTransactionsContext();
 
+  const formatCategory = (transaction) => {
+    return transaction.category === "Other"
+      ? `${transaction.category} (${transaction.name})`
+      : transaction.category;
+  };
+
+  const renderAmount = (transaction) => (
+    <span
+      className={clsx(
+        "font-medium",
+        transaction.type === "income" ? "text-green-500" : "text-red-500"
+      )}
+    >
+      {transaction.type === "income" ? "+" : "-"}
+      {formatAmount(transaction.amount, selectedCurrency)}
+    </span>
+  );
+
+  const renderActions = (transaction, mobile = false) => (
+    <div className={clsx("flex items-center", mobile ? "gap-3" : "gap-4")}>
+      <button
+        onClick={() => handleEditTransaction(transaction.id)}
+        title="Edit transaction"
+        aria-label="Edit transaction"
+        className={clsx(
+          "cursor-pointer transition",
+          mobile
+            ? "text-blue-500 hover:text-blue-600"
+            : "text-[rgb(var(--color-brand-deep))] hover:text-[rgb(var(--color-brand))]"
+        )}
+      >
+        <HiOutlinePencil className="text-base" />
+      </button>
+      <button
+        onClick={() =>
+          deleteTransaction(user.uid, "transactions", transaction.id)
+        }
+        title="Delete transaction"
+        aria-label="Delete transaction"
+        className="cursor-pointer text-red-500 transition hover:text-red-600"
+      >
+        <HiOutlineTrash className="text-base" />
+      </button>
+    </div>
+  );
+
+  const columns = [
+    {
+      key: "date",
+      header: "Date",
+      render: (transaction) => transaction.date,
+      cellClassName: "whitespace-nowrap",
+    },
+    {
+      key: "description",
+      header: "Description",
+      render: (transaction) => transaction.description || "No description",
+    },
+    {
+      key: "category",
+      header: "Category",
+      render: formatCategory,
+    },
+    {
+      key: "amount",
+      header: "Amount",
+      render: renderAmount,
+      cellClassName: "whitespace-nowrap",
+    },
+    {
+      key: "actions",
+      header: "",
+      render: (transaction) => renderActions(transaction),
+      cellClassName: "whitespace-nowrap",
+      hideOnMobile: true,
+    },
+  ];
+
   return (
     <div>
-      {/* <ScrollToTop /> */}
       <h3 className="text-lg md:text-xl mb-8 text-[rgb(var(--color-muted))] font-semibold">
         Showing {indexOfFirstTransaction + 1}-
         {Math.min(indexOfLastTransaction, sortedTransactions.length)} of{" "}
         {sortedTransactions.length} transactions
       </h3>
 
-      {/* Tablet & Desktop View */}
-      <table className="hidden md:table min-w-full divide-y divide-[rgb(var(--color-gray-border))] bg-[rgb(var(--color-bg-card))] rounded-lg shadow-sm p-4 overflow-hidden">
-        <thead className="bg-[rgb(var(--color-bg-card))]">
-          <tr>
-            <th className="text-left text-[rgb(var(--color-muted))] p-2">
-              Date
-            </th>
-            <th className="text-left text-[rgb(var(--color-muted))] p-2">
-              Description
-            </th>
-            <th className="text-left text-[rgb(var(--color-muted))] p-2">
-              Category
-            </th>
-            <th className="text-left text-[rgb(var(--color-muted))] p-2">
-              Amount
-            </th>
-            <th className="text-left text-[rgb(var(--color-muted))] p-2"></th>
-          </tr>
-        </thead>
-        <tbody className="bg-[rgb(var(--color-bg-card))] divide-y divide-[rgb(var(--color-gray-border))] text-[13px]">
-          {currentTransactions.map((transaction) => (
-            <tr key={transaction.id}>
-              <td className="p-2">{transaction.date}</td>
-              <td className="p-2">
-                {transaction.description || "No description"}
-              </td>
-              <td className="p-2">
-                {transaction.category === "Other"
-                  ? `${transaction.category} (${transaction.name})`
-                  : transaction.category}
-              </td>
-              <td
-                className={clsx(
-                  "p-2 font-medium",
-                  transaction.type === "income"
-                    ? "text-green-500"
-                    : "text-red-500"
-                )}
-              >
-                {transaction.type === "income" ? "+" : "-"}
-                {formatAmount(transaction.amount, selectedCurrency)}
-              </td>
-              <td className="p-2">
-                <button
-                  onClick={() => handleEditTransaction(transaction.id)}
-                  className="cursor-pointer text-[rgb(var(--color-brand-deep))] hover:text-[rgb(var(--color-brand))] transition mr-4"
-                >
-                  <HiOutlinePencil className="text-base" />
-                </button>
-                <button
-                  onClick={() =>
-                    deleteTransaction(user.uid, "transactions", transaction.id)
-                  }
-                  className="cursor-pointer text-red-500 hover:text-red-600 transition"
-                >
-                  <HiOutlineTrash className="text-base" />
-                </button>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-
-      {/* Mobile View */}
-      <div className="flex flex-col md:hidden gap-8">
-        {currentTransactions.map((transaction) => (
-          <div key={transaction.id} className="flex flex-col gap-4">
+      <ResponsiveTable
+        columns={columns}
+        rows={currentTransactions}
+        getRowKey={(transaction) => transaction.id}
+        emptyMessage="No transactions found."
+        mobileRow={(transaction) => (
+          <div className="flex flex-col gap-4">
             <h4 className="text-base font-semibold">
               {transaction.description || "No description"}
             </h4>
 
             <div className="flex items-center gap-1">
-              <div className="grow grid grid-cols-3 gap-1 text-[13px]">
+              <div className="grid grow grid-cols-1 gap-2 text-[13px] min-[420px]:grid-cols-3">
                 <p className="flex items-center gap-1">
-                  <span className="w-2 h-2 bg-[rgb(var(--color-muted))] rounded-full"></span>
+                  <span className="h-2 w-2 rounded-full bg-[rgb(var(--color-muted))]"></span>
                   <span>{transaction.date}</span>
                 </p>
                 <p className="flex items-center gap-1">
-                  <span className="w-2 h-2 bg-[rgb(var(--color-muted))] rounded-full"></span>
-                  <span>
-                    {transaction.category === "Other"
-                      ? `${transaction.category} (${transaction.name})`
-                      : transaction.category}
-                  </span>
+                  <span className="h-2 w-2 rounded-full bg-[rgb(var(--color-muted))]"></span>
+                  <span>{formatCategory(transaction)}</span>
                 </p>
                 <p className="flex items-center gap-1">
-                  <span className="w-2 h-2 bg-[rgb(var(--color-muted))] rounded-full"></span>
-                  <span
-                    className={clsx(
-                      "font-medium",
-                      transaction.type === "income"
-                        ? "text-green-500"
-                        : "text-red-500"
-                    )}
-                  >
-                    {transaction.type === "income" ? "+" : "-"}
-                    {formatAmount(transaction.amount, selectedCurrency)}
-                  </span>
+                  <span className="h-2 w-2 rounded-full bg-[rgb(var(--color-muted))]"></span>
+                  {renderAmount(transaction)}
                 </p>
               </div>
-              <button
-                onClick={() => handleEditTransaction(transaction.id)}
-                className="cursor-pointer text-blue-500 hover:text-blue-600 transition mr-3"
-              >
-                <HiOutlinePencil className="text-base" />
-              </button>
-              <button
-                onClick={() =>
-                  deleteTransaction(user.uid, "transactions", transaction.id)
-                }
-                className="cursor-pointer text-red-500 hover:text-red-600 transition"
-              >
-                <HiOutlineTrash className="text-base" />
-              </button>
+              {renderActions(transaction, true)}
             </div>
           </div>
-        ))}
-      </div>
+        )}
+      />
 
       {/* Pagination Controls */}
       {sortedTransactions?.length > 10 && (

--- a/src/components/ui/ResponsiveTable.jsx
+++ b/src/components/ui/ResponsiveTable.jsx
@@ -1,0 +1,104 @@
+import clsx from "clsx";
+
+const ResponsiveTable = ({
+  columns = [],
+  rows = [],
+  getRowKey,
+  emptyMessage = "No records found.",
+  mobileRow,
+  className,
+  tableClassName,
+}) => {
+  const renderCell = (column, row) => {
+    if (typeof column.render === "function") return column.render(row);
+    return row?.[column.key] ?? "";
+  };
+
+  return (
+    <div className={className}>
+      <div
+        className={clsx(
+          "hidden overflow-x-auto rounded-md border border-[rgb(var(--color-gray-border))] bg-[rgb(var(--color-bg-card))] md:block",
+          tableClassName
+        )}
+      >
+        <table className="min-w-full text-sm">
+          <thead className="bg-[rgb(var(--color-gray-bg))] text-left text-[rgb(var(--color-muted))]">
+            <tr>
+              {columns.map((column) => (
+                <th
+                  key={column.key}
+                  className={clsx("px-4 py-3 font-semibold", column.headerClassName)}
+                >
+                  {column.header}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, index) => (
+              <tr
+                key={getRowKey(row, index)}
+                className="border-t border-[rgb(var(--color-gray-border))]"
+              >
+                {columns.map((column) => (
+                  <td
+                    key={column.key}
+                    className={clsx("px-4 py-3", column.cellClassName)}
+                  >
+                    {renderCell(column, row)}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        {!rows.length && (
+          <p className="px-4 py-10 text-center text-[rgb(var(--color-muted))]">
+            {emptyMessage}
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-4 md:hidden">
+        {rows.map((row, index) => (
+          <div
+            key={getRowKey(row, index)}
+            className="rounded-md border border-[rgb(var(--color-gray-border))] bg-[rgb(var(--color-bg-card))] p-4"
+          >
+            {typeof mobileRow === "function" ? (
+              mobileRow(row, { columns, renderCell })
+            ) : (
+              <dl className="grid gap-3 text-sm">
+                {columns
+                  .filter((column) => !column.hideOnMobile)
+                  .map((column) => (
+                    <div
+                      key={column.key}
+                      className="flex items-start justify-between gap-4"
+                    >
+                      <dt className="text-[rgb(var(--color-muted))]">
+                        {column.header}
+                      </dt>
+                      <dd className="text-right font-medium">
+                        {renderCell(column, row)}
+                      </dd>
+                    </div>
+                  ))}
+              </dl>
+            )}
+          </div>
+        ))}
+
+        {!rows.length && (
+          <p className="rounded-md border border-[rgb(var(--color-gray-border))] bg-[rgb(var(--color-bg-card))] px-4 py-10 text-center text-[rgb(var(--color-muted))]">
+            {emptyMessage}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ResponsiveTable;

--- a/src/pages/Insights.jsx
+++ b/src/pages/Insights.jsx
@@ -1,24 +1,30 @@
-import { useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import ScrollToTop from "../layout/ScrollToTop";
 import useAuthStore from "../store/useAuthStore";
 import useInsightsStore from "../store/useInsightsStore";
 import InsightCard from "../components/insights/InsightCard";
+import InsightHistoryTable from "../components/insights/InsightHistoryTable";
 import { motion } from "framer-motion";
 import useOnboardingStore from "../store/useOnboardingStore";
 import {normalizeInsight} from "../utils/normalizeInsight";
+
+const INSIGHTS_PER_PAGE = 4;
 
 const Insights = () => {
   const isUserEmailVerified = useAuthStore(
     (state) => state.isUserEmailVerified
   );
   const insights = useInsightsStore((state) => state.insights);
+  const insightsHistory = useInsightsStore((state) => state.insightsHistory);
   const aiLimitReached = useInsightsStore(state => state.aiLimitReached);
+  const [activeView, setActiveView] = useState("insights");
+  const [currentPage, setCurrentPage] = useState(1);
 
-  const { setCurrentPage, startTourIfNotCompleted } = useOnboardingStore();
+  const { setCurrentPage: setOnboardingPage, startTourIfNotCompleted } = useOnboardingStore();
 
   useEffect(() => {
-    setCurrentPage("insights");
-    // Start tour if not completed when navigating to insights page (only if email verified)
+    setOnboardingPage("insights");
+    
     if (!isUserEmailVerified) return;
 
     const timer = setTimeout(() => {
@@ -26,7 +32,26 @@ const Insights = () => {
     }, 500);
 
     return () => clearTimeout(timer);
-  }, [setCurrentPage, startTourIfNotCompleted, isUserEmailVerified]);
+  }, [setOnboardingPage, startTourIfNotCompleted, isUserEmailVerified]);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [insights.length]);
+
+  const normalizedinsights = useMemo(
+    () => insights?.map(ins => normalizeInsight(ins)) ?? [],
+    [insights]
+  );
+
+  const sortedInsights = useMemo(
+    () => [...normalizedinsights].sort((a, b) => b.createdAt - a.createdAt),
+    [normalizedinsights]
+  );
+  const totalPages = Math.max(1, Math.ceil(sortedInsights.length / INSIGHTS_PER_PAGE));
+  const paginatedInsights = sortedInsights.slice(
+    (currentPage - 1) * INSIGHTS_PER_PAGE,
+    currentPage * INSIGHTS_PER_PAGE
+  );
 
   if (!isUserEmailVerified) {
     return (
@@ -44,10 +69,6 @@ const Insights = () => {
     );
   }
 
-  const normalizedinsights = insights?.map(ins => normalizeInsight(ins));
-
-  const sortedInsights = normalizedinsights?.sort((a, b) => a.createdAt - b.createdAt);
-
   return (
     <motion.main
       initial={{ opacity: 0, y: 20 }}
@@ -63,6 +84,34 @@ const Insights = () => {
       <p className="text-base text-[rgb(var(--color-muted))] mb-10">
         Personalized suggestions, forecasts and savings tips.
       </p>
+
+      <div className="mb-8 flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={() => setActiveView("insights")}
+          className={`rounded-md border px-4 py-2 text-sm font-semibold transition ${
+            activeView === "insights"
+              ? "border-[rgb(var(--color-brand))] bg-[rgb(var(--color-brand))] text-white"
+              : "border-[rgb(var(--color-gray-border))] bg-[rgb(var(--color-bg-card))] text-[rgb(var(--color-text))]"
+          }`}
+        >
+          Active Insights
+        </button>
+        <button
+          type="button"
+          onClick={() => setActiveView("history")}
+          className={`rounded-md border px-4 py-2 text-sm font-semibold transition ${
+            activeView === "history"
+              ? "border-[rgb(var(--color-brand))] bg-[rgb(var(--color-brand))] text-white"
+              : "border-[rgb(var(--color-gray-border))] bg-[rgb(var(--color-bg-card))] text-[rgb(var(--color-text))]"
+          }`}
+        >
+          History
+          <span className="ml-2 rounded-full bg-[rgb(var(--color-gray-bg))] px-2 py-0.5 text-xs text-[rgb(var(--color-muted))]">
+            {insightsHistory.length}
+          </span>
+        </button>
+      </div>
 
       {aiLimitReached && (
         <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-4 flex flex-col gap-2 mb-10">
@@ -87,8 +136,11 @@ const Insights = () => {
         </div>
       )}
 
-      {/* Empty State */}
-      {!sortedInsights?.length && (
+      {activeView === "history" && (
+        <InsightHistoryTable histories={insightsHistory} />
+      )}
+
+      {activeView === "insights" && !sortedInsights?.length && (
         <div
           id="insights-empty-state"
           className="flex justify-center text-center mt-14"
@@ -101,16 +153,41 @@ const Insights = () => {
       )}
 
 
-      {/* Smart Insights */}
-      {!!sortedInsights?.length && (
-        <div
-          id="insights-grid"
-          className="grid grid-cols-1 mdl:grid-cols-2 gap-6"
-        >
-          {sortedInsights?.map((insight) => (
-            <InsightCard key={insight.id} insight={insight} />
-          ))}
-        </div>
+      {activeView === "insights" && !!sortedInsights?.length && (
+        <>
+          <div
+            id="insights-grid"
+            className="grid grid-cols-1 mdl:grid-cols-2 gap-6"
+          >
+            {paginatedInsights?.map((insight) => (
+              <InsightCard key={insight.id} insight={insight} />
+            ))}
+          </div>
+
+          {totalPages > 1 && (
+            <div className="mt-8 flex items-center justify-center gap-3">
+              <button
+                type="button"
+                onClick={() => setCurrentPage((page) => Math.max(1, page - 1))}
+                disabled={currentPage === 1}
+                className="rounded-md border border-[rgb(var(--color-gray-border))] bg-[rgb(var(--color-bg-card))] px-4 py-2 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Previous
+              </button>
+              <span className="text-sm text-[rgb(var(--color-muted))]">
+                Page {currentPage} of {totalPages}
+              </span>
+              <button
+                type="button"
+                onClick={() => setCurrentPage((page) => Math.min(totalPages, page + 1))}
+                disabled={currentPage === totalPages}
+                className="rounded-md border border-[rgb(var(--color-gray-border))] bg-[rgb(var(--color-bg-card))] px-4 py-2 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Next
+              </button>
+            </div>
+          )}
+        </>
       )}
     </motion.main>
   );

--- a/src/store/useInsightsStore.js
+++ b/src/store/useInsightsStore.js
@@ -3,91 +3,53 @@ import { persist } from "zustand/middleware";
 import { v4 as uuid } from "uuid";
 import {
   collection,
-  deleteDoc,
-  doc,
   onSnapshot,
-  serverTimestamp,
 } from "firebase/firestore";
 import { db } from "../firebase/firebase";
-import { addDocument, getAllDocuments } from "../firebase/firestore";
-import useCurrencyStore from "./useCurrencyStore";
-import { formatAmount } from "../utils/formatAmount";
-import { toast } from "react-hot-toast";
-
-const EXPIRY_MS = 2 * 24 * 60 * 60 * 1000;
+import { updateDocument } from "../firebase/firestore";
 
 const useInsightsStore = create(
   persist(
-    (set, get) => ({
+    (set) => ({
       insights: [],
+      insightsHistory: [],
       insightError: null,
       aiLimitReached: false,
 
       setInsightError: (message) => set({insightError: message}),
       setAILimitReached: (bool) => set({aiLimitReached: bool}),
 
-      // Generation lock to prevent multiple simultaneous insight generation
-      isGeneratingInsights: false,
-      lastGenerationTime: 0,
-
-      // Subscribe to realtime updates and clean expired ones
       initInsights: (uid) => {
         const colRef = collection(db, "users", uid, "insights");
 
         return onSnapshot(colRef, async (snapshot) => {
           const now = Date.now();
           const list = [];
+          const history = [];
 
           for (const document of snapshot.docs) {
             const data = document.data();
             const expired = data.expiresAt && data.expiresAt < now;
 
             if (expired) {
-              // Delete from firestore
-              await deleteDoc(doc(db, "users", uid, "insights", document.id));
-              continue;
+              history.push(formatInsightHistory({ data, expired }));
+
+              if (data.status !== "EXPIRED") {
+                await updateDocument(uid, "insights", document.id, {status: "EXPIRED"});
+              }
+            } else {
+              const activeInsight = { id: document.id, ...data, status: "ACTIVE" };
+
+              history.push(formatInsightHistory({ data: activeInsight, expired }));
+              list.push(activeInsight);
             }
-            list.push({ id: document.id, ...data });
           }
 
-          set({ insights: list });
+          set({ insights: list, insightsHistory: history });
         });
       },
 
-      // Add new insight with expiry (persist all insights to Firestore)
-      // addInsight: async (uid, insight) => {
-        
-
-      //   const insightWithExpiry = {
-      //     ...insight,
-      //     expiresAt: Date.now() + EXPIRY_MS,
-      //   };
-
-      //   // Optimistic update: show locally immediately
-      //   set((state) => ({ insights: [...state.insights, insightWithExpiry] }));
-
-      //   if (!uid) return;
-
-      //   try {
-      //     await addDocument(uid, "insights", insightWithExpiry);
-
-      //     // Refetch all insights
-      //     const docs = await getAllDocuments(uid, "insights");
-
-      //     set({ insights: docs });
-      //   } catch (err) {
-      //     console.warn("Failed to persist insight to Firestore:", err);
-      //   }
-      //   // Toast message for new insights
-      //   toast.success(
-      //     `New insight for ${insightWithExpiry?.category}: Check Insight page for more info.`,
-      //     {
-      //       duration: 10000,
-      //     }
-      //   );
-      // },
-
-      clearInsightsStore: () => set({ insights: [] }),
+      clearInsightsStore: () => set({ insights: [], insightsHistory: [] }),
     }),
     {
       name: "insights-storage",
@@ -95,5 +57,30 @@ const useInsightsStore = create(
     }
   )
 );
+
+const formatInsightHistory = ({ data, expired }) => {
+  const type = normalizeHistoryType(data.type);
+  const status = expired || data.status === "EXPIRED" ? "EXPIRED" : "ACTIVE";
+  const category = ["anomaly", "budget"].includes(type) ? data.category ?? null : null;
+
+  return {
+    id: uuid(),
+    type,
+    status,
+    category,
+    severity: (data.severity || "LOW").toUpperCase(),
+    createdAt: data.createdAt,
+    expiresAt: data.expiresAt,
+  };
+};
+
+const normalizeHistoryType = (type) => {
+  if (type === "financial-risk") return "risk";
+  if (type === "budget-compliance" || type === "budget") return "budget";
+  if (type === "cashflow") return "cashflow";
+  if (type === "anomaly") return "anomaly";
+
+  return type || "unknown";
+};
 
 export default useInsightsStore;


### PR DESCRIPTION
Summary:

Adds Insight History support and improves insight/transaction table rendering with a shared responsive table UI.

Changes:

- Populate insightsHistory from Firestore with both ACTIVE and EXPIRED insights.
- Normalize history records into a lightweight schema for history views.
- Mark persisted insights as ACTIVE and extend insight expiry to 7 days.
- Add an Insight History tab with type/status filters and date-based sorting.
- Add simple pagination for active insights.
- Add reusable ResponsiveTable UI for desktop tables and mobile card layouts.
- Refactor Transactions table to use the shared responsive table component.
- Refactor Insight History table to use the same responsive table style.
- Clean up redundant insight fields like actionType/local createdAt where persistence now owns lifecycle metadata.
- Update orchestrator tests to match structured failure/empty-result responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an **Insight History** view with filtering and a mobile-friendly table layout.
  * Improved the insights page with separate **Active Insights** and **History** tabs, plus pagination for active items.
  * Updated transaction lists to use a more responsive table experience across screen sizes.

* **Bug Fixes**
  * Insights now remain available longer before expiring.
  * Insight statuses are handled more consistently, improving how active and expired items appear in the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->