### PR TITLE
Add scalable AI pipeline telemetry with categorized sharded Firestore metrics, agent fallback instrumentation, and updated orchestrator tests

### DIFF
--- a/backend/ai/orchestrator/agentExecution.js
+++ b/backend/ai/orchestrator/agentExecution.js
@@ -2,6 +2,7 @@ import { fallback as anomalyFallback } from "../fallbacks/anomaly.js";
 import { fallback as budgetFallback } from "../fallbacks/budget.js";
 import { fallback as cashflowFallback } from "../fallbacks/cashflow.js";
 import { riskFallback } from "../fallbacks/risk.js";
+import { logAIAgentRun } from "../telemetry/logger.js";
 
 export const AGENT_TIMEOUT_MS = 25000;
 
@@ -17,21 +18,60 @@ export const runAgentWithFallback = async ({
     selectedSignal,
     userId,
     isDemo,
+    runId,
+    telemetryContext = {},
     timeoutMs = AGENT_TIMEOUT_MS
 }) => {
+    const startedAtMs = Date.now();
+
     try {
-        return await runAgentWithTimeout({
+        const insight = await runAgentWithTimeout({
             agent,
             selectedSignal,
             userId,
             isDemo,
             timeoutMs
         });
+
+        await logAIAgentRun({
+            ...telemetryContext,
+            userId,
+            runId,
+            agentType: selectedSignal.type,
+            selectedSignalId: selectedSignal.id,
+            durationMs: Date.now() - startedAtMs,
+            status: "success",
+            timedOut: false,
+            schemaValid: true,
+            usedFallback: false,
+            modelUsed: insight?.modelUsed ?? null,
+        });
+
+        return insight;
     } catch (agentExecutionError) {
-        return buildFallbackInsight({
+
+        const fallbackInsight = buildFallbackInsight({
             selectedSignal,
             error: agentExecutionError
         });
+
+        await logAIAgentRun({
+            ...telemetryContext,
+            userId,
+            runId,
+            agentType: selectedSignal.type,
+            selectedSignalId: selectedSignal.id,
+            durationMs: Date.now() - startedAtMs,
+            status: "fallback",
+            timedOut: agentExecutionError.code === "AI_PROVIDER_TIMEOUT",
+            schemaValid: agentExecutionError.code === "AI_OUTPUT_MALFORMED" ? false : null,
+            usedFallback: true,
+            fallbackReason: agentExecutionError.message ?? "Agent execution failed",
+            modelUsed: fallbackInsight?.modelUsed ?? "rule-based",
+            error: agentExecutionError,
+        });
+
+        return fallbackInsight;
     }
 };
 
@@ -40,7 +80,9 @@ const runAgentWithTimeout = async ({ agent, selectedSignal, userId, isDemo, time
 
     const timeoutPromise = new Promise((_, reject) => {
         timeoutId = setTimeout(() => {
-            reject(new Error("AI provider timed out"));
+            const error = new Error("AI provider timed out");
+            error.code = "AI_PROVIDER_TIMEOUT"
+            reject(error);
         }, timeoutMs);
     });
 
@@ -51,7 +93,9 @@ const runAgentWithTimeout = async ({ agent, selectedSignal, userId, isDemo, time
         ]);
 
         if (!isValidInsight(insight)) {
-            throw new Error("AI output malformed");
+            const error = new Error("AI output malformed");
+            error.code = "AI_OUTPUT_MALFORMED";
+            throw error;
         }
 
         return insight;

--- a/backend/ai/orchestrator/reserveSignal.js
+++ b/backend/ai/orchestrator/reserveSignal.js
@@ -1,0 +1,61 @@
+import { buildTrigger, getTriggerRef } from "../triggers/lib.js";
+import { db, FieldValue } from "../../../lib/firebaseAdmin.js";
+import { evaluateTrigger } from "../triggers/evaluateTrigger.js";
+
+export const reserveSelectedSignal = async ({userId, selectedSignal, candidateSignals}) => {
+    const orderedSignals = [
+        selectedSignal,
+        ...candidateSignals.filter(signal => signal.id !== selectedSignal.id)
+    ];
+
+    for (const signal of orderedSignals) {
+        const reservation = await reserveSignalTrigger({userId, signal});
+
+        if(reservation.allowed) {
+            return signal;
+        }
+    }
+
+    return null;
+}
+
+
+export const reserveSignalTrigger = async ({ userId, signal } = {}) => {
+    const trigger = buildTrigger(signal);
+
+    if (!userId || !trigger) {
+        return { allowed: false, reason: "INVALID_TRIGGER" };
+    }
+
+    const ref = getTriggerRef({ userId, triggerKey: trigger.key });
+    const now = Date.now();
+
+    return await db.runTransaction(async transaction => {
+        const snap = await transaction.get(ref);
+        const existing = snap.exists ? snap.data() : null;
+        const eligibility = evaluateTrigger({ existing, trigger, now });
+
+        if (!eligibility.allowed) {
+            return eligibility;
+        }
+
+        const payload = {
+            triggerKey: trigger.key,
+            type: trigger.type,
+            status: "reserved",
+            reason: eligibility.reason,
+            signalId: signal.id ?? null,
+            severity: signal.severity ?? null,
+            fingerprint: trigger.fingerprint,
+            snapshot: trigger.snapshot,
+            reservedAt: FieldValue.serverTimestamp(),
+            reservedAtMs: now,
+            updatedAt: FieldValue.serverTimestamp(),
+            updatedAtMs: now,
+        };
+
+        transaction.set(ref, payload, { merge: true });
+
+        return { allowed: true, reason: eligibility.reason, triggerKey: trigger.key };
+    });
+};

--- a/backend/ai/orchestrator/triggerGate.js
+++ b/backend/ai/orchestrator/triggerGate.js
@@ -1,24 +1,6 @@
-import { db, FieldValue } from "../../../lib/firebaseAdmin.js";
-import {TRIGGER_BUILDERS} from "../triggers/builders.js";
-import {TRIGGER_COLLECTION} from "../triggers/utils.js";
+import { FieldValue } from "../../../lib/firebaseAdmin.js";
 import {evaluateTrigger} from "../triggers/evaluateTrigger.js";
-
-const getTriggerRef = ({ userId, triggerKey }) => {
-    return db
-        .collection("users")
-        .doc(userId)
-        .collection(TRIGGER_COLLECTION)
-        .doc(triggerKey);
-};
-
-const buildTrigger = signal => {
-    if (!signal?.type || !signal?.data) return null;
-
-    const builder = TRIGGER_BUILDERS[signal.type];
-    if (!builder) return null;
-
-    return builder(signal);
-};
+import {buildTrigger, getTriggerRef} from "../triggers/lib.js";
 
 export const filterEligibleSignals = async ({ userId, signals = [] } = {}) => {
     if (!userId || !Array.isArray(signals) || !signals.length) return [];
@@ -33,6 +15,7 @@ export const filterEligibleSignals = async ({ userId, signals = [] } = {}) => {
     return checks.filter(Boolean);
 };
 
+
 export const checkSignalEligibility = async ({ userId, signal } = {}) => {
     const trigger = buildTrigger(signal);
 
@@ -46,45 +29,6 @@ export const checkSignalEligibility = async ({ userId, signal } = {}) => {
     return evaluateTrigger({ existing: snap.exists ? snap.data() : null, trigger, now: Date.now() });
 };
 
-export const reserveSignalTrigger = async ({ userId, signal } = {}) => {
-    const trigger = buildTrigger(signal);
-
-    if (!userId || !trigger) {
-        return { allowed: false, reason: "INVALID_TRIGGER" };
-    }
-
-    const ref = getTriggerRef({ userId, triggerKey: trigger.key });
-    const now = Date.now();
-
-    return await db.runTransaction(async transaction => {
-        const snap = await transaction.get(ref);
-        const existing = snap.exists ? snap.data() : null;
-        const eligibility = evaluateTrigger({ existing, trigger, now });
-
-        if (!eligibility.allowed) {
-            return eligibility;
-        }
-
-        const payload = {
-            triggerKey: trigger.key,
-            type: trigger.type,
-            status: "reserved",
-            reason: eligibility.reason,
-            signalId: signal.id ?? null,
-            severity: signal.severity ?? null,
-            fingerprint: trigger.fingerprint,
-            snapshot: trigger.snapshot,
-            reservedAt: FieldValue.serverTimestamp(),
-            reservedAtMs: now,
-            updatedAt: FieldValue.serverTimestamp(),
-            updatedAtMs: now,
-        };
-
-        transaction.set(ref, payload, { merge: true });
-
-        return { allowed: true, reason: eligibility.reason, triggerKey: trigger.key };
-    });
-};
 
 export const markSignalTriggered = async ({ userId, signal, insight } = {}) => {
     const trigger = buildTrigger(signal);

--- a/backend/ai/services/orchestrator.js
+++ b/backend/ai/services/orchestrator.js
@@ -8,8 +8,14 @@ import {
     filterEligibleSignals,
     markSignalTriggered,
     markSignalTriggerFailed,
-    reserveSignalTrigger
 } from "../orchestrator/triggerGate.js";
+import { reserveSelectedSignal } from "../orchestrator/reserveSignal.js";
+import {
+    buildTelemetryContext,
+    createTelemetryRunId,
+    logAIPipelineRun,
+    logInsightEvent
+} from "../telemetry/logger.js"
 
 import {runAnomalyService} from "./anomaly.js";
 import {runBudgetService} from "./budget.js";
@@ -31,6 +37,10 @@ export const runOrchestrator = async ({
     riskData,
     isDemo
  }) => {
+    const runId = createTelemetryRunId();
+    const startedAtMs = Date.now();
+
+    const telemetryContext = buildTelemetryContext({userId, isDemo})
 
     const rawSignals = normalizeSignals({
         anomalies, 
@@ -39,7 +49,22 @@ export const runOrchestrator = async ({
         riskData
     });
 
-    if(!rawSignals.length) return [];
+    if(!rawSignals.length) {
+        await logAIPipelineRun({
+            ...telemetryContext,
+            userId,
+            runId,
+            status: "blocked",
+            reason: "NO_RAW_SIGNALS",
+            durationMs: Date.now() - startedAtMs,
+            rawSignalCount: 0,
+            scoredSignalCount: 0,
+            attentionAllowed: false,
+            persisted: false,
+        });
+
+        return [];
+    };
 
     const scoredSignals = scoreSignals({signals: rawSignals});
     const topSignal = scoredSignals[0];
@@ -51,6 +76,26 @@ export const runOrchestrator = async ({
     });
 
     if(!attentionDecision.allowed) {
+        await logAIPipelineRun({
+            ...telemetryContext,
+            userId,
+            runId,
+            status: "blocked",
+            reason: attentionDecision.reason,
+            durationMs: Date.now() - startedAtMs,
+
+            rawSignalCount: rawSignals.length,
+            scoredSignalCount: scoredSignals.length,
+            topSignalType: topSignal?.type ?? null,
+            topSignalId: topSignal?.id ?? null,
+            topSignalScore: topSignal?.urgencyScore ?? null,
+
+            attentionAllowed: false,
+            attentionReason: attentionDecision.reason,
+
+            persisted: false,
+        })
+
         return {
             insight: null,
             scoredSignals,
@@ -62,6 +107,30 @@ export const runOrchestrator = async ({
     const eligibleSignals = await filterEligibleSignals({userId, signals: [selectedCandidate]});
 
     if(!eligibleSignals.length) {
+        await logAIPipelineRun({
+            ...telemetryContext,
+            userId,
+            runId, 
+            status: "blocked",
+            reason: "NO_ELIGIBLE_SIGNAL",
+            durationMs: Date.now() - startedAtMs,
+
+            rawSignalCount: rawSignals.length,
+            scoredSignalCount: scoredSignals.length,
+            topSignalType: topSignal?.type ?? null,
+            topSignalId: topSignal?.id ?? null,
+            topSignalScore: topSignal?.urgencyScore ?? null,
+            
+            selectedSignalType: selectedCandidate?.type ?? null,
+            selectedSignalId: selectedCandidate?.id ?? null,
+
+            attentionAllowed: true,
+            attentionReason: attentionDecision.reason,
+
+            triggerEligible: false,
+            persisted: false,
+        });
+
         return {
             insight: null,
             reason: "NO_ELIGIBLE_SIGNAL"
@@ -84,6 +153,31 @@ export const runOrchestrator = async ({
     });
 
     if(!reservedSelection) {
+        await logAIPipelineRun({
+            ...telemetryContext,
+            userId,
+            runId,
+            status: "blocked",
+            reason: "NO_RESERVED_SELECTION",
+            durationMs: Date.now() - startedAtMs,
+
+            rawSignalCount: rawSignals.length,
+            scoredSignalCount: scoredSignals.length,
+            topSignalType: topSignal?.type ?? null,
+            topSignalId: topSignal?.id ?? null,
+            topSignalScore: topSignal?.urgencyScore ?? null,
+
+            selectedSignalType: selectedSignal?.type ?? null,
+            selectedSignalId: selectedSignal?.id ?? null,
+
+            attentionAllowed: true,
+            attentionReason: attentionDecision.reason,
+
+            triggerEligible: true,
+            reservationAllowed: false,
+            persisted: false,
+        });
+
         return {
             insight: null,
             reason: "NO_RESERVED_SELECTION"
@@ -108,7 +202,9 @@ export const runOrchestrator = async ({
             agent,
             selectedSignal,
             userId,
-            isDemo
+            isDemo,
+            runId,
+            telemetryContext
         });
     } catch (fallbackExecutionError) {
         await markSignalTriggerFailed({userId, signal: selectedSignal, error: fallbackExecutionError});
@@ -134,6 +230,40 @@ export const runOrchestrator = async ({
     const persisted = await persistInsights({userId, insight});
 
     if(!persisted) {
+        await logAIPipelineRun({
+            ...telemetryContext,
+            userId, 
+            runId,
+            status: "failed",
+            reason: "INSIGHT_PERSISTENCE_FAILED",
+            durationMs: Date.now() - startedAtMs,
+
+            rawSignalCount: rawSignals.length,
+            scoredSignalCount: scoredSignals.length,
+            topSignalType: topSignal?.type ?? null,
+            topSignalId: topSignal?.id ?? null,
+            topSignalScore: topSignal?.urgencyScore ?? null,
+
+            selectedSignalType: selectedSignal?.type ?? null,
+            selectedSignalId: selectedSignal?.id ?? null,
+
+
+            attentionAllowed: true,
+            attentionReason: attentionDecision.reason,
+
+            triggerEligible: true,
+            reservationAllowed: true,
+
+            persisted: false,
+            usedFallback: Boolean(insight?.isFallback),
+            insightId: insight?.id ?? null,
+            insightType: insight?.type ?? null,
+            severity: insight?.severity ?? selectedSignal?.severity ?? null,
+
+
+            error: new Error("Insight persistence failed"),
+        });
+
         await markSignalTriggerFailed({
             userId,
             signal: selectedSignal,
@@ -146,25 +276,53 @@ export const runOrchestrator = async ({
         };
     }
 
+    await logInsightEvent({
+        ...telemetryContext,
+        userId,
+        runId,
+        eventType: "INSIGHT_GENERATED",
+        insightId: insight?.id ?? null,
+        insightType: insight?.type ?? null,
+        selectedSignalId: selectedSignal?.id ?? null,
+        selectedSignalType: selectedSignal?.type ?? null,
+        severity: insight.severity ?? selectedSignal?.severity ?? null,
+        isFallback: Boolean(insight?.isFallback),
+        modelUsed: insight?.modelUsed ?? null,
+        reason: attentionDecision.reason,
+    });
+
     await markSignalTriggered({userId, signal: selectedSignal, insight});
     await saveAttentionState({userId, signal: selectedSignal, scoredSignals, insight});
 
+    await logAIPipelineRun({
+        ...telemetryContext,
+        userId,
+        runId,
+        status: insight?.isFallback ? "fallback" :"success",
+        reason: attentionDecision.reason,
+        durationMs: Date.now() - startedAtMs,
+
+        rawSignalCount: rawSignals.length,
+        scoredSignalCount: scoredSignals.length,
+        topSignalType: topSignal?.type ?? null,
+        topSignalId: topSignal?.id ?? null,
+        topSignalScore: topSignal?.urgencyScore ?? null,
+
+        selectedSignalType: selectedSignal?.type ?? null,
+        selectedSignalId: selectedSignal?.id ?? null, 
+
+        attentionAllowed: true,
+        attentionReason: attentionDecision.reason,
+
+        triggerEligible: true,
+        reservationAllowed: true,
+
+        persisted: true,
+        usedFallback: Boolean(insight?.isFallback),
+        insightId: insight?.id ?? null,
+        insightType: insight?.type ?? null,
+        severity: insight?.severity ?? selectedSignal?.severity ?? null,
+    });
+
     return {insight, scoredSignals, reason: attentionDecision.reason};
-}
-
-const reserveSelectedSignal = async ({userId, selectedSignal, candidateSignals}) => {
-    const orderedSignals = [
-        selectedSignal,
-        ...candidateSignals.filter(signal => signal.id !== selectedSignal.id)
-    ];
-
-    for (const signal of orderedSignals) {
-        const reservation = await reserveSignalTrigger({userId, signal});
-
-        if(reservation.allowed) {
-            return signal;
-        }
-    }
-
-    return null;
 }

--- a/backend/ai/telemetry/logger.js
+++ b/backend/ai/telemetry/logger.js
@@ -1,0 +1,214 @@
+import { randomUUID } from "crypto";
+import { writeTelemetryEvent } from "./writeTelemetryEvent.js";
+
+export const createTelemetryRunId = () => `run_${randomUUID()}`;
+
+export const buildTelemetryContext = ({
+    userId,
+    institutionId = null,
+    pilotId = null,
+    cohortId = null,
+    isDemo = false,
+    environment = process.env.NODE_ENV || "development"
+} = {}) => {
+    return {
+        userId,
+        institutionId,
+        pilotId,
+        cohortId,
+        isDemo: Boolean(isDemo),
+        environment
+    }
+};
+
+
+export const logAIPipelineRun = async ({
+    userId,
+    runId,
+    institutionId = null,
+    pilotId = null,
+    cohortId = null,
+    environment = process.env.NODE_ENV || "development",
+    isDemo = false,
+
+    status,
+    reason = null,
+    durationMs = null,
+
+    rawSignalCount = 0,
+    scoredSignalCount = 0,
+    topSignalType = null,
+    topSignalId = null,
+    topSignalScore = null,
+
+    selectedSignalType = null,
+    selectedSignalId = null,
+
+    attentionAllowed = null,
+    attentionReason = null,
+
+    triggerEligible = null,
+    reservationAllowed = null,
+    reservationReason = null,
+
+    persisted = null,
+    usedFallback = false,
+    insightId = null,
+    insightType = null,
+    severity = null,
+
+    error = null,
+} = {}) => {
+    return writeTelemetryEvent({
+        userId,
+        category: "aiPipelineRuns",
+        eventId: runId,
+        payload: {
+            runId,
+            institutionId,
+            pilotId,
+            cohortId,
+            environment,
+            isDemo,
+
+            status,
+            reason,
+            durationMs,
+
+            rawSignalCount,
+            scoredSignalCount,
+            topSignalType,
+            topSignalId,
+            topSignalScore,
+
+            selectedSignalType,
+            selectedSignalId,
+
+            attentionAllowed,
+            attentionReason,
+
+            triggerEligible,
+            reservationAllowed,
+            reservationReason,
+
+            persisted,
+            usedFallback,
+            insightId,
+            insightType,
+            severity,
+
+            error: serializeTelemetryError(error),
+        },
+    });
+};
+
+
+export const logAIAgentRun = async ({
+    userId,
+    runId,
+    agentRunId = `agent_${randomUUID()}`,
+    institutionId = null,
+    pilotId = null,
+    cohortId = null,
+    environment = process.env.NODE_ENV || "development",
+    isDemo = false,
+
+    agentType, 
+    selectedSignalId = null,
+    durationMs = null,
+
+    status,
+    timedOut = false,
+    schemaValid = null,
+    usedFallback = false,
+    fallbackReason = null,
+    modelUsed = null,
+
+    error = null,
+} = {}) => {
+    return writeTelemetryEvent({
+        userId,
+        category: "aiAgentRuns",
+        eventId: agentRunId,
+        payload: {
+            runId,
+            agentRunId,
+            institutionId,
+            pilotId,
+            cohortId,
+            environment,
+            isDemo,
+
+            agentType,
+            selectedSignalId,
+            durationMs,
+
+            status,
+            timedOut,
+            schemaValid,
+            usedFallback,
+            fallbackReason,
+            modelUsed,
+
+            error: serializeTelemetryError(error),
+        },
+    });
+};
+
+
+export const logInsightEvent = async ({
+    userId,
+    runId,
+    eventId = `insight_event_${randomUUID()}`,
+    institutionId = null,
+    pilotId = null,
+    cohortId = null,
+    environment = process.env.NODE_ENV || "development",
+    isDemo = false,
+
+    eventType,
+    insightId = null,
+    insightType = null,
+    selectedSignalId = null,
+    selectedSignalType = null,
+    severity = null,
+    isFallback = false,
+    modelUsed = null,
+    reason = null,
+} = {}) => {
+    return writeTelemetryEvent ({
+        userId,
+        category: "insightEvents",
+        eventId,
+        payload: {
+            runId,
+            eventId,
+            institutionId,
+            pilotId,
+            cohortId,
+            environment,
+            isDemo,
+
+            eventType,
+            insightId,
+            insightType,
+            selectedSignalId,
+            selectedSignalType,
+            severity,
+            isFallback,
+            modelUsed,
+            reason
+        },
+    });
+};
+
+
+const serializeTelemetryError = error => {
+    if (!error) return null;
+
+    return {
+        name: error.name ?? "Error",
+        message: error.message ?? "Unknown telemetry error",
+        code: error.code ?? null,
+    }
+}

--- a/backend/ai/telemetry/utils.js
+++ b/backend/ai/telemetry/utils.js
@@ -1,0 +1,17 @@
+const METRIC_SHARD_COUNT = 100;
+
+export const getDateKey = ( timestampMs ) => new Date(timestampMs).toISOString().slice(0, 10);
+
+export const getDailyMetricId = ({ dateKey, category }) => `${dateKey}__${category}`;
+
+export const getMetricShardId = (value) => {
+    const input = String(value ?? "");
+    let hash = 0;;
+
+    for(let i =0; i < input.length; i++) {
+        hash = ((hash << 5) - hash) + input.charCodeAt(i);
+        hash |= 0;
+    }
+
+    return String(Math.abs(hash) % METRIC_SHARD_COUNT);
+}

--- a/backend/ai/telemetry/writeTelemetryEvent.js
+++ b/backend/ai/telemetry/writeTelemetryEvent.js
@@ -1,0 +1,233 @@
+import { db, FieldValue } from "../../../lib/firebaseAdmin.js";
+import { getDateKey, getDailyMetricId, getMetricShardId } from "./utils.js";
+
+const TELEMETRY_ROOT = "telemetry";
+
+export const writeTelemetryEvent  = async ({ userId, category, eventId, payload }) => {
+    if (!userId || !category || !eventId) return false;
+    
+    const now = Date.now();
+    const dateKey = getDateKey(now);
+    const shardId = getMetricShardId(eventId);
+
+    const eventPayload = {
+        ...payload,
+        category,
+        createdAt: FieldValue.serverTimestamp(),
+        createdAtMs: now
+    };
+
+    try {
+        const batch = db.batch();
+    
+        const userEventRef = buildUserEventRef({userId, category, eventId});
+        batch.set(userEventRef, eventPayload, {merge: true});
+
+        if(payload?.institutionId) {
+            const institutionEventRef = buildInstitutionEventRef({
+                institutionId: payload.institutionId,
+                category,
+                eventId
+            });
+
+            batch.set(institutionEventRef, eventPayload, { merge: true });
+        };
+
+        queueTelemetryAggregates({
+            batch, 
+            category,
+            payload: eventPayload,
+            dateKey,
+            shardId,
+            now
+        });
+
+        await batch.commit();
+
+        return true;
+    } catch (err) {
+        console.error("TELEMETRY_WRITE_FAILED:", err);
+        return false;
+    }
+
+};
+
+const buildUserEventRef = ({ userId, category, eventId }) => {
+    return db
+    .collection("users")
+    .doc(userId)
+    .collection(TELEMETRY_ROOT)
+    .doc(category)
+    .collection("events")
+    .doc(eventId);
+};
+
+const buildInstitutionEventRef = ({ institutionId, category, eventId }) => {
+    return db
+    .collection("institutions")
+    .doc(institutionId)
+    .collection(category)
+    .doc(eventId);
+};
+
+const queueTelemetryAggregates = ({ batch, category, payload, dateKey, shardId, now }) => {
+    const dailyMetricPatch = buildDailyMetricPatch({ 
+        category,
+        payload, 
+        dateKey, 
+        shardId, 
+        now 
+    });
+
+    if(!dailyMetricPatch) return null;
+
+    if(payload?.institutionId && payload?.pilotId) {
+        const institutionDailyMetricShardRef = buildInstitutionDailyMetricShardRef({ 
+            institutionId: payload.institutionId,
+            pilotId: payload.pilotId,
+            dateKey,
+            category,
+            shardId,
+         });
+
+         batch.set(institutionDailyMetricShardRef, dailyMetricPatch, { merge: true });
+    }
+
+    const globalDailyMetricShardRef = buildGlobalDailyMetricShardRef({ 
+        dateKey,
+        category,
+        shardId
+    });
+    batch.set(globalDailyMetricShardRef, dailyMetricPatch, { merge: true });
+};
+
+const buildInstitutionDailyMetricShardRef = ({ institutionId, pilotId, dateKey, category, shardId }) => {
+    return db
+    .collection("institutions")
+    .doc(institutionId)
+    .collection("pilots")
+    .doc(pilotId)
+    .collection("dailyMetrics")
+    .doc(getDailyMetricId({dateKey, category}))
+    .collection("shards")
+    .doc(shardId);
+};
+
+const buildGlobalDailyMetricShardRef = ({ dateKey, category, shardId }) => {
+    return db
+    .collection("globalMetrics")
+    .doc("daily")
+    .collection("records")
+    .doc(getDailyMetricId({dateKey, category}))
+    .collection("shards")
+    .doc(shardId);
+};
+
+const buildDailyMetricPatch = ({ category, payload, dateKey, shardId, now }) => {
+    if(category === "aiPipelineRuns") {
+        return buildPipelineDailyMetricPatch({ 
+            payload, 
+            dateKey, 
+            shardId, 
+            now 
+        });
+    }
+    
+    if(category === "aiAgentRuns") {
+        return buildAgentDailyMetricPatch({ 
+            payload, 
+            dateKey, 
+            shardId, 
+            now 
+        });
+    }
+
+    if(category === "insightEvents") {
+        return buildInsightDailyMetricPatch({ 
+            payload, 
+            dateKey, 
+            shardId, 
+            now 
+        });
+    }
+
+    return null;
+}
+
+const buildPipelineDailyMetricPatch = ({ payload, dateKey, shardId, now }) => {
+    return {
+        dateKey,
+        shardId,
+
+        totalPipelineRuns: FieldValue.increment(1),
+        successfulPipelineRuns: FieldValue.increment(payload.status === "success" ? 1 : 0),
+        fallbackPipelineRuns: FieldValue.increment(payload.status === "fallback" ? 1 : 0),
+        failedPipelineRuns: FieldValue.increment(payload.status === "failed" ? 1 : 0),
+        blockedPipelineRuns: FieldValue.increment(payload.status === "blocked" ? 1 : 0),
+
+        totalPipelineDurationMs: FieldValue.increment(payload.durationMs ?? 0),
+
+        persistedInsights: FieldValue.increment(payload.persisted ? 1 : 0),
+        fallbackInsights: FieldValue.increment(payload.usedFallback ? 1 : 0),
+
+        rawSignalsSeen: FieldValue.increment(payload.rawSignalCount ?? 0),
+        scoredSignalsSeen: FieldValue.increment(payload.scoredSignalCount ?? 0),
+
+        attentionAllowedRuns: FieldValue.increment(payload.attentionAllowed === true ? 1 : 0),
+        attentionBlockedRuns: FieldValue.increment(payload.attentionAllowed === false ? 1 : 0),
+
+        triggerEligibleRuns: FieldValue.increment(payload.triggerEligible === true ? 1 : 0),
+        triggerBlockedRuns: FieldValue.increment(payload.triggerEligible === false ? 1 : 0),
+
+        reservationAllowedRuns: FieldValue.increment(payload.reservationAllowed === true ? 1 : 0),
+        reservationBlockedRuns: FieldValue.increment(payload.reservationAllowed === false ? 1 : 0),
+
+        updatedAt: FieldValue.serverTimestamp(),
+        updatedAtMs: now,
+    };
+};
+
+const buildAgentDailyMetricPatch = ({ payload, dateKey, shardId, now }) => {
+    return {
+        dateKey,
+        shardId,
+
+        totalAgentRuns: FieldValue.increment(1),
+        successfulAgentRuns: FieldValue.increment(payload.status === "success" ? 1 : 0),
+        fallbackAgentRuns: FieldValue.increment(payload.usedFallback ? 1 : 0),
+        failedAgentRuns: FieldValue.increment(payload.status === "failed" ? 1 : 0),
+
+        timeoutAgentRuns: FieldValue.increment(payload.timedOut ? 1 : 0),
+        malformedAgentRuns: FieldValue.increment(payload.schemaValid === false ? 1 : 0),
+
+        totalAgentDurationMs: FieldValue.increment(payload.durationMs ?? 0),
+
+        updatedAt: FieldValue.serverTimestamp(),
+        updatedAtMs: now,
+    };
+};
+
+const buildInsightDailyMetricPatch = ({ payload, dateKey, shardId, now }) => {
+    return {
+        dateKey,
+        shardId,
+
+        totalInsightEvents: FieldValue.increment(1),
+        generatedInsights: FieldValue.increment(payload.eventType === "INSIGHT_GENERATED" ? 1 : 0),
+
+        fallbackInsightEvents: FieldValue.increment(payload.isFallback ? 1 : 0),
+
+        highSeverityInsights: FieldValue.increment(
+            String(payload.severity ?? "").toUpperCase() === "HIGH" ? 1 : 0
+        ),
+        mediumSeverityInsights: FieldValue.increment(
+            String(payload.severity ?? "").toUpperCase() === "MEDIUM" ? 1 : 0
+        ),
+        lowSeverityInsights: FieldValue.increment(
+            String(payload.severity ?? "").toUpperCase() === "LOW" ? 1 : 0
+        ),
+
+        updatedAt: FieldValue.serverTimestamp(),
+        updatedAtMs: now,
+    }
+}

--- a/backend/ai/triggers/lib.js
+++ b/backend/ai/triggers/lib.js
@@ -1,0 +1,20 @@
+import { db } from "../../../lib/firebaseAdmin.js";
+import { TRIGGER_BUILDERS } from "./builders.js";
+import { TRIGGER_COLLECTION } from "./utils.js";
+
+export const getTriggerRef = ({ userId, triggerKey }) => {
+    return db
+        .collection("users")
+        .doc(userId)
+        .collection(TRIGGER_COLLECTION)
+        .doc(triggerKey);
+};
+
+export const buildTrigger = signal => {
+    if (!signal?.type || !signal?.data) return null;
+
+    const builder = TRIGGER_BUILDERS[signal.type];
+    if (!builder) return null;
+
+    return builder(signal);
+};

--- a/backend/tests/orchestrator.test.js
+++ b/backend/tests/orchestrator.test.js
@@ -9,7 +9,10 @@ vi.mock("../ai/orchestrator/triggerGate.js", () => ({
   filterEligibleSignals: vi.fn(),
   markSignalTriggered: vi.fn(),
   markSignalTriggerFailed: vi.fn(),
-  reserveSignalTrigger: vi.fn(),
+}));
+
+vi.mock("../ai/orchestrator/reserveSignal.js", () => ({
+  reserveSelectedSignal: vi.fn(),
 }));
 
 vi.mock("../ai/orchestrator/persistInsights.js", () => ({
@@ -40,14 +43,29 @@ vi.mock("../ai/services/risk.js", () => ({
   runRiskService: vi.fn(),
 }));
 
+vi.mock("../ai/telemetry/logger.js", () => ({
+  buildTelemetryContext: vi.fn(({ userId, isDemo }) => ({
+    userId,
+    institutionId: null,
+    pilotId: null,
+    cohortId: null,
+    isDemo: Boolean(isDemo),
+    environment: "test",
+  })),
+  createTelemetryRunId: vi.fn(() => "run-test"),
+  logAIAgentRun: vi.fn(() => Promise.resolve(true)),
+  logAIPipelineRun: vi.fn(() => Promise.resolve(true)),
+  logInsightEvent: vi.fn(() => Promise.resolve(true)),
+}));
+
 import { runOrchestrator } from "../ai/services/orchestrator.js";
 import { generateAIResponse } from "../ai/services/aiClient.js";
 import {
   filterEligibleSignals,
   markSignalTriggered,
   markSignalTriggerFailed,
-  reserveSignalTrigger,
 } from "../ai/orchestrator/triggerGate.js";
+import { reserveSelectedSignal } from "../ai/orchestrator/reserveSignal.js";
 import { evaluateAttentionGate } from "../ai/orchestrator/attentionGate.js";
 import { saveAttentionState } from "../ai/orchestrator/attentionState.js";
 import { persistInsights } from "../ai/orchestrator/persistInsights.js";
@@ -55,6 +73,11 @@ import { runAnomalyService } from "../ai/services/anomaly.js";
 import { runBudgetService } from "../ai/services/budget.js";
 import { runCashflowService } from "../ai/services/cashflow.js";
 import { runRiskService } from "../ai/services/risk.js";
+import {
+  logAIAgentRun,
+  logAIPipelineRun,
+  logInsightEvent,
+} from "../ai/telemetry/logger.js";
 
 const anomaly = {
   id: "anomaly-food",
@@ -117,7 +140,7 @@ describe("orchestrator", () => {
     evaluateAttentionGate.mockResolvedValue({ allowed: true, reason: "NO_ACTIVE_EPISODE" });
     saveAttentionState.mockResolvedValue(true);
     filterEligibleSignals.mockImplementation(async ({ signals }) => signals);
-    reserveSignalTrigger.mockResolvedValue({ allowed: true });
+    reserveSelectedSignal.mockImplementation(async ({ selectedSignal }) => selectedSignal);
     persistInsights.mockResolvedValue(true);
     generateAIResponse.mockResolvedValue({
       selectedSignalId: "risk-jun",
@@ -191,6 +214,13 @@ describe("orchestrator", () => {
     expect(persistInsights).toHaveBeenCalledTimes(1);
     expect(markSignalTriggered).toHaveBeenCalledTimes(1);
     expect(saveAttentionState).toHaveBeenCalledTimes(1);
+    expect(logInsightEvent).toHaveBeenCalledTimes(1);
+    expect(logAIPipelineRun).toHaveBeenCalledWith(expect.objectContaining({
+      runId: "run-test",
+      status: "success",
+      persisted: true,
+      selectedSignalId: "risk-jun",
+    }));
   });
 
   it("preserves deterministic engine output for the selected top signal", async () => {
@@ -222,6 +252,12 @@ describe("orchestrator", () => {
     });
     expect(markSignalTriggered).toHaveBeenCalledTimes(1);
     expect(markSignalTriggerFailed).not.toHaveBeenCalled();
+    expect(logAIAgentRun).toHaveBeenCalledWith(expect.objectContaining({
+      runId: "run-test",
+      status: "fallback",
+      usedFallback: true,
+      selectedSignalId: "risk-jun",
+    }));
   });
 
   it("persists a local fallback insight when the agent times out", async () => {
@@ -285,11 +321,16 @@ describe("orchestrator", () => {
   });
 
   it("returns no insight when the top signal reservation loses a race", async () => {
-    reserveSignalTrigger.mockResolvedValueOnce({ allowed: false, reason: "ALREADY_RESERVED" });
+    reserveSelectedSignal.mockResolvedValueOnce(null);
 
     const result = await runPipeline();
 
-    expect(reserveSignalTrigger).toHaveBeenCalledTimes(1);
+    expect(reserveSelectedSignal).toHaveBeenCalledTimes(1);
+    expect(reserveSelectedSignal).toHaveBeenCalledWith({
+      userId: "user-orchestrator",
+      selectedSignal: expect.objectContaining({ id: "risk-jun" }),
+      candidateSignals: [expect.objectContaining({ id: "risk-jun" })],
+    });
     expect(runAnomalyService).not.toHaveBeenCalled();
     expect(runRiskService).not.toHaveBeenCalled();
     expect(result).toEqual({ insight: null, reason: "NO_RESERVED_SELECTION" });
@@ -302,7 +343,7 @@ describe("orchestrator", () => {
     vi.clearAllMocks();
     evaluateAttentionGate.mockResolvedValue({ allowed: true, reason: "NO_ACTIVE_EPISODE" });
     filterEligibleSignals.mockImplementation(async ({ signals }) => signals);
-    reserveSignalTrigger.mockResolvedValue({ allowed: true });
+    reserveSelectedSignal.mockImplementation(async ({ selectedSignal }) => selectedSignal);
     persistInsights.mockResolvedValue(true);
     generateAIResponse.mockResolvedValue({
       selectedSignalId: "risk-jun",

--- a/src/insight_engines/runInsights.js
+++ b/src/insight_engines/runInsights.js
@@ -28,9 +28,8 @@ export const generateInsight = async ({ userId, transactions, budgets}) => {
     const riskData = buildRiskData(anomalies, budgetComplianceList, cashflowData, transactions);
 
     try {
-      const insights = await fetchInsight({userId, riskData, anomalies, budgetComplianceList, cashflowData });
+      await fetchInsight({userId, riskData, anomalies, budgetComplianceList, cashflowData });
       
-      console.log(insights)
     } catch (err) {
       console.error("Error:", err);
     }


### PR DESCRIPTION
## Summary

This PR adds telemetry to the SmartBudget AI pipeline so each run can be measured during pilot trials. It records when the pipeline succeeds, gets blocked, falls back to local insight text, or fails.

## What Changed

- Added telemetry for full AI pipeline runs.
- Added telemetry for individual AI agent runs, including timeout and fallback cases.
- Added telemetry for generated insights.
- Added daily aggregate metrics for global reporting.
- Added optional institution and pilot-level metrics when those IDs are available.
- Added sharded metric writes to reduce Firestore write pressure during high activity.
- Moved signal reservation logic into its own helper file.
- Updated orchestrator tests to match the new pipeline flow.

## Why

This gives SmartBudget measurable evidence for institution pilots, including:

- AI pipeline reliability
- fallback activation rate
- insight generation volume
- blocked run reasons
- agent timeout or malformed-output cases
- basic performance timing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive monitoring for AI pipeline runs, agent executions, fallbacks, errors, durations, and generated insights.
  * Added reliable signal reservation with duplicate prevention and eligibility checks.
  * Added aggregated daily telemetry metrics for pipeline and insight activity.

* **Bug Fixes**
  * Improved handling and classification of timeout, invalid output, reservation, and persistence failures.

* **Tests**
  * Expanded coverage for successful runs, fallback behavior, signal reservation, and telemetry logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->